### PR TITLE
terms of service page added

### DIFF
--- a/Pages/about.html
+++ b/Pages/about.html
@@ -154,7 +154,7 @@
                     <p>Created by: Andrew Leinster, Iona Cavill, Adam Munro, Laura Clark, Rickie Kumar and Oscar Weir
                     </p>
                 </li>
-                <li><a href="">Terms of Service</a></li>
+                <li><a href="./termsOfService.html">Terms of Service</a></li>
                 <li><a href="">FAQ</a></li>
             </ul>
         </footer>

--- a/Pages/duckPage.html
+++ b/Pages/duckPage.html
@@ -46,7 +46,7 @@
         <li>
           <p>Created by: Andrew Leinster, Iona Cavill, Adam Munro, Laura Clark, Rickie Kumar and Oscar Weir</p>
         </li>
-        <li><a href="">Terms of Service</a></li>
+        <li><a href="./termsOfService.html">Terms of Service</a></li>
         <li><a href="">FAQ</a></li>
       </ul>
     </footer>

--- a/Pages/moreInfo.html
+++ b/Pages/moreInfo.html
@@ -52,7 +52,7 @@
             <li>
               <p>Created by: Andrew Leinster, Iona Cavill, Adam Munro, Laura Clark, Rickie Kumar and Oscar Weir</p>
             </li>
-            <li><a href="">Terms of Service</a></li>
+            <li><a href="./termsOfService.html">Terms of Service</a></li>
             <li><a href="">FAQ</a></li>
           </ul>
         </footer>

--- a/Pages/termsOfService.html
+++ b/Pages/termsOfService.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head id="head">
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
+    <link href="../bootstrap/bootstrap.min.css" rel="stylesheet">
+    <link href="../Styling/lightmode.css" rel="stylesheet" id="link">
+    <link rel="icon" href="../Styling/Browser icon.png" sizes="32x32" type="image/png">
+
+    <title>Compute Commute</title>
+</head>
+
+<body>
+    <!--Navbar-->
+    <nav class="navbar navbar-expand p-3 navbarStyle">
+        <div class="container-fluid">
+            <a class="navbar-brand text-white" href="../index.html">
+                <img src="../Styling/LightLogo.png" alt="Logo Design">
+            </a>
+            <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                <li class="nav-item">
+                    <a class="nav-link navbarText" href="./about.html">About</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link navbarText" href="./duckPage.html">Ducks</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link activeLink" aria-current="page" href="termsOfService.html">Terms Of Service</a>
+                </li>
+            </ul>
+
+            <button type="button" class="btn btn-primary buttonStyle" id="themebtn">Change theme</button>
+
+    </nav>
+
+    <div class="container mt-5 aboutContainer" id="containerbox">
+
+        <h1 class="tosHeading">Terms Of Use for Compute Commute</h1>
+
+        <p>Successful toy salesman Scott Calvin prepares to spend Christmas Eve with his son Charlie. Scott wants
+            Charlie to maintain his belief in Santa Claus, despite not believing himself. Scott's former wife, Laura,
+            and her psychiatrist husband Dr. Neil Miller, both stopped believing in Santa at a young age and feel that
+            Charlie needs to do so as well (after an older kid made Charlie upset by saying Santa is not real).
+
+            On Christmas Eve Scott burns the turkey he was cooking, so he and Charlie go to Denny's for dinner. The two
+            share an uneventful evening and go to sleep. They are awakened by a noise on the roof. Scott startles a man
+            wearing a Santa suit standing on the roof, who slips and falls to the ground. The man's body vanishes,
+            leaving behind a red suit and business card that states: "If something should happen to me, put on my suit.
+            The reindeer will know what to do." Scott and Charlie find a sleigh and reindeer still on the roof. At
+            Charlie's request, Scott dons the suit and spends the rest of the night delivering gifts before the reindeer
+            take them to the North Pole. Bernard the head elf explains that, by putting on the suit, Scott is subject to
+            a legal technicality known as "The Santa Clause", and has accepted all of Santa's duties and
+            responsibilities. Bernard gives Scott eleven months to get his affairs in order before reporting back to the
+            North Pole on Thanksgiving. Confused and overwhelmed, Scott changes into the pajamas provided to him and
+            falls asleep.
+
+            Awakening in his own bed, Scott thinks it was all a dream (though he is confused that he is wearing the
+            North Pole pajamas). Laura, Neil, and the school staff are concerned when Charlie proudly tells his school
+            class that Scott is Santa. Not wanting to destroy Charlie's newfound enthusiasm, Scott asks him to keep
+            their North Pole trip a secret. Over the course of the year, strange things begin to happen to Scott. His
+            hair turns white and a beard constantly re-grows, even immediately after shaving. He develops an increased
+            fondness for sweets, primarily milk and cookies. He gains an inordinate amount of weight seemingly
+            overnight. During a meeting with his company, Scott becomes angry at a proposal to advertise a toy military
+            tank by showing Santa riding it. He also begins to recount 'naughty' and 'nice' children by name when he
+            sees them. After Laura and Neil witness children wanting to sit on Scott's lap at Charlie's soccer game,
+            they assume Scott is deliberately misleading Charlie and decide to have a judge suspend Scott's visitation
+            rights. At Thanksgiving, a desperate Scott goes to Laura and Neil's house to see to Charlie but Neil will
+            not let him anywhere near Charlie. When Neil insists that Scott is not Santa, Charlie shows Scott a magical
+            snow globe that Bernard had given him, finally convincing Scott that he really is Santa. When Laura and Neil
+            allow Scott a minute to talk to Charlie alone, Bernard appears and transports him and Charlie to the North
+            Pole. Thinking Scott has kidnapped Charlie, Laura and Neil call the police.
+
+            On Christmas Eve, Scott sets out to deliver gifts with Charlie in tow. Upon arriving at Laura and Neil's
+            home, Scott is arrested inside the house while Charlie waits for him in the sleigh. The elves send a team to
+            break him out of jail. Scott returns Charlie to his house and insists he spend Christmas Eve with Laura and
+            Neil. His heartfelt speech to Charlie about the importance of everyone in the family convinces Laura and
+            Neil that he is Santa. Laura burns the court papers suspending Scott's visitation rights, and tells Scott he
+            can visit anytime. Bernard appears and tells Charlie that any time he shakes his magical snow globe his
+            father will appear. Before leaving, Scott gives Laura and Neil the two Christmas presents that they never
+            got as children, which had caused their disbelief in Santa.
+
+            Charlie summons Scott back with the snow globe and Laura agrees to let Charlie go with Scott in the sleigh
+            to finish delivering the presents.</p>
+
+        <h1 class="tosHeading">Other Terms and Conditions</h1>
+
+        <p>Eight years have passed since Scott Calvin took on the mantle of Santa Claus. Head Elf Bernard and Curtis,
+            the Keeper of the Handbook of Christmas, inform Scott that there is another clause — the "Mrs. Clause".
+            Scott is now pressed to get married before the next Christmas Eve or the clause will be broken and he will
+            stop being Santa forever. At the same time, Abby the Elf delivers even more distressing news: Scott's
+            teenage son Charlie is on the naughty list, due to having vandalized his school to get attention. Scott must
+            return to his home to search for a wife and set things right with Charlie. He brings this up when visited by
+            the Council of Legendary Figures, consisting of Mother Nature, Father Time, Cupid, the Easter Bunny, the
+            Tooth Fairy, and the Sandman. To cover for Santa's prolonged absence, Curtis helps Scott create a life-sized
+            animatronic Santa clone, much to Bernard's horror. However, at Santa's request, Bernard reluctantly plays
+            along, and tells the other elves that Santa had a makeover, so they will not question the double's synthetic
+            appearance.
+
+            Because of the impending end of his contract, Scott undergoes a "de-Santafication process" that gradually
+            turns him back into Scott Calvin. He has a limited amount of magic to help him. Scott returns home to his
+            former wife Laura, her husband Neil, their six-year-old daughter Lucy, and Charlie. He and Charlie face the
+            ire of school principal Carol Newman when Charlie defaces the lockers.
+
+            At the North Pole, Toy Santa follows the rulebook too literally and begins to think that everyone in the
+            world is naughty because of their small mistakes. As a result, Toy Santa takes over the North Pole using
+            giant toy soldiers he made himself and unveils his plan to the elves to give lumps of coal to the world.
+            Bernard exposes Toy Santa as a fraud, and Toy Santa places him under house arrest.
+
+            After a few failed dates, Scott finds himself falling for Carol. He accompanies her in a horse-drawn sleigh
+            to the faculty Christmas party, during which she confesses she used to believe in Santa as a child, until
+            she was forced to stop doing so by her parents after fighting with children who told her Santa was not real.
+            Using a little of his Christmas magic, Scott enlivens the otherwise dull party by presenting everyone with
+            their childhood dream gifts. He makes a special presentation to Carol, and, with his last remnant of magic,
+            wins her over and they kiss under mistletoe. However, when Scott attempts to explain to her that he is
+            Santa, she believes that he is mocking her childhood, and throws him out. Later, Charlie is upset about
+            Scott dating his principal and he confesses how hard it is for him that Scott is never around like other
+            fathers, and reveals the pressure he is under to conceal the secret that his father is Santa. Lucy manages
+            to convince Charlie not to be mad at him, which leads Charlie to convince Carol that Scott is Santa by
+            showing her the magic snow globe he received during Scott's initial transformation.
+
+            Curtis flies in to tell Scott about Toy Santa's plan. However, Scott has used up the last of his magic
+            wooing Carol, and cannot return to the North Pole. With help from the Tooth Fairy, Scott and Curtis manage
+            to get back, only for Toy Santa to find them and tie them up. Charlie and Carol spring them free by
+            summoning the Tooth Fairy to fly them to the North Pole. Scott goes after Toy Santa, who has already left
+            with the sleigh, riding Chet, a rambunctious reindeer-in-training, and they both crash back into the
+            village. With an army of elves, Carol, Bernard, Charlie, and Curtis lead them into a snowball fight to
+            overthrow the toy soldiers. Toy Santa is defeated and reduced to a six-inch height, Scott marries Carol in a
+            ceremony, Scott transforms back into Santa and Carol transforms into Mrs. Claus, and Christmas proceeds as
+            it always has. Scott and Charlie reveal the truth to Lucy about Scott being Santa Claus, promising to keep
+            his secret.</p>
+
+        <h1 class="tosHeading">User Privacy</h1>
+
+        <p>Twelve years have passed since Scott Calvin took on the mantle of Santa Claus and married Carol Newman, who
+            is now a teacher in the North Pole. On Christmas Eve, she tells a group of young elves a story from her
+            life with Scott while expecting their first child. Scott invites his in-laws, Sylvia and Bud Newman, to the
+            North Pole, along with Scott's ex-wife Laura, her husband Neil, their daughter Lucy, and Scott's son
+            Charlie. Meanwhile, he is summoned to a meeting of the Council of Legendary Figures, consisting of Mother
+            Nature, Father Time, the Easter Bunny, Cupid, the Tooth Fairy, and the Sandman, concerning the behavior of
+            Jack Frost, who is jealous that he has no holiday or special occasion in his honor. Because he has been
+            promoting himself during the Christmas season, Mother Nature suggests sanctions against him. As Scott is
+            attempting to get the in-laws to come without revealing that he is Santa, Jack Frost negotiates a light
+            sentence of community service at the North Pole, helping Scott and the elves put up various Canadian-themed
+            paraphernalia, as Carol's parents believe Scott is a toymaker in Canada; Scott consents.
+
+            However, Frost's ultimate goal is to trick Santa into renouncing his position. When now Head elf Curtis
+            inadvertently reveals the "Escape Clause", Frost sneaks into The Hall of Snow Globes and steals Scott's one
+            containing Scott as Santa. If Scott holds the globe and wishes to have "never been Santa at all," he will go
+            back in time and undo his career as Santa. When Lucy discovers this, Frost freezes her parents and locks her
+            in a closet. He then orchestrates situations that make Scott think he must resign to make things better.
+
+            Frost tricks Scott into invoking the Escape Clause and both are sent to Scott's front yard in 1994, when
+            Scott caused the original Santa to fall off his roof and had to replace him. Frost causes the original Santa
+            to fall off the roof and grabs Santa's coat before Scott can. Scott is sent to an alternate 2006, where he
+            has been CEO of his old company for the last twelve years and business takes priority over family. Scott
+            also learns that Laura and Neil divorced and Carol moved away years ago.
+
+            Scott goes to find Lucy and Neil, who are vacationing at the North Pole, which Frost has turned into a theme
+            park. Christmas is now "Frostmas", the elves are miserable, the reindeer are confined to a petting zoo, and
+            parents can pay for their kids to be placed on the nice list. Scott finds Lucy and questions Neil about
+            Laura; he states that Scott's workaholic absence in Charlie's life put all the pressure on Neil, and Charlie
+            didn't want him to be his father, causing the divorce between him and Laura.
+
+            Scott confronts Frost and causes a distraction and convinces Lucy to steal Frost's snow globe for him. Lucy
+            throws the snow globe to Scott, but Frost catches it. Scott plays a recording of Frost saying "I wish I'd
+            never been Santa at all" from a novelty North Pole pen Frost gave him earlier, invoking the Escape Clause,
+            sending both Scott and Frost back to 1994. Scott restrains Jack long enough to let his 1994 counterpart get
+            the coat, making him Santa Claus again, sending both back to the present in the original timeline.
+
+            Scott reconciles with his family and Jack is arrested by elf police. He reveals he cannot unfreeze his
+            victims unless he unfreezes himself, something he says he'll never do. Scott convinces Lucy via a snow globe
+            he had given her earlier of her warmly hugging a snowman, to give Frost a "magic hug" to unfreeze and reform
+            him. It works, Laura and Neil unfreeze and Frost becomes a new person. The "Canada" ruse is dropped and
+            Scott appears as Santa to Carol's parents. With two hours remaining before Santa must leave for his
+            Christmas deliveries, Carol goes into labor.
+
+            Months later, while Carol is telling the tale to her students, Scott walks in to reveal their son, Buddy
+            Claus.</p>
+
+
+    </div>
+
+    <!--Footer-->
+    <div class="container-fluid text-center p-2 mt-5">
+        <footer>
+            <ul class="list-unstyled">
+                <li>
+                    <p>Created by: Andrew Leinster, Iona Cavill, Adam Munro, Laura Clark, Rickie Kumar ands Oscar Weir
+                    </p>
+                </li>
+                <li><a href="./termsOfService.html">Terms of Service</a></li>
+                <li><a href="./faq.htmk">FAQ</a></li>
+            </ul>
+        </footer>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4"
+        crossorigin="anonymous"></script>
+
+    <script src="../Javascript/theme_pages.js"></script>
+
+</body>
+
+</html>

--- a/Styling/darkmode.css
+++ b/Styling/darkmode.css
@@ -256,3 +256,7 @@ padding-bottom: -15px;
 
 }
 
+.tosHeading{
+    margin-top: 20px;
+    margin-bottom: 20px;
+}

--- a/Styling/lightmode.css
+++ b/Styling/lightmode.css
@@ -256,3 +256,8 @@ padding-bottom: -15px;
 
 }
 
+.tosHeading{
+    margin-top: 20px;
+    margin-bottom: 20px;
+}
+

--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
         <li>
           <p>Created by: Andrew Leinster, Iona Cavill, Adam Munro, Laura Clark, Rickie Kumar and Oscar Weir</p>
         </li>
-        <li><a href="">Terms of Service</a></li>
+        <li><a href="./Pages/termsOfService.html">Terms of Service</a></li>
         <li><a href="">FAQ</a></li>
       </ul>
     </footer>


### PR DESCRIPTION
The current filler text is the synopses of the three mainline Santa Clause movies. If anyone has strong feelings toward this being changed that can be done although I would advise against actually trying to produce legal documentation. Link to tos page will have to be added to faq in a later commit once #75  has been merged